### PR TITLE
Improve documentation for usage with PHP-FPM

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,5 @@ export MATOMO_DATABASE_PASSWORD=secure
 ### Known issues:
 * Configuration arrays are currently not supported, for example you cannot define which `Plugins[]` should be loaded.
 * At some point your Matomo may save/write the config file, for example when changing certain settings through the UI such as the trusted hosts. In this case, the currently read environment variables will be saved in the config file.
+* If this plugin is used with PHP-FPM, for example in combination with NGINX, PHP-FPM will not have access to the environment variables by default. The pool used by PHP-FPM must either explicit define which ENVs should be exposed, or set `clear_env = no` in `/etc/php7/php-fpm.f/<pool>.conf`.
 


### PR DESCRIPTION
Add note on PHP-FPM usage.

For this plugin to work with PHP-FPM, it needs to be configured so that ENVs are exposed to PHP-FPM. The default (https://www.php.net/manual/en/install.fpm.configuration.php) is to strip all ENVs:

> clear_env boolean
> Clear environment in FPM workers. Prevents arbitrary environment variables from reaching FPM worker processes by clearing the environment in workers before env vars specified in this pool configuration are added. Since PHP 5.4.27, 5.5.11, and 5.6.0. Default value: Yes.

closes #1 
closes #2 

