### PR TITLE
Prepare for Matomo 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### 6.0.0 - 2026-08-10
+- Compatibility with Matomo 6
+
 ### 5.0.3 - 2025-01-20
 - Added missing license file
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,10 +1,10 @@
 {
     "name": "EnvironmentVariables",
     "description": "Allows you to specify Matomo config in environment variables instead of the config file.",
-    "version": "5.0.3",
+    "version": "6.0.0",
     "theme": false,
     "require": {
-        "matomo": ">=5.0.0-b1,<6.0.0-b1"
+        "matomo": ">=6.0.0-b1,<7.0.0-b1"
     },
     "authors": [
         {


### PR DESCRIPTION
## Description

Prepares the plugin for Matomo 6.

- `plugin.json`: version `5.0.3` → `6.0.0`, and `require.matomo` → `>=6.0.0-b1,<7.0.0-b1`. The `-b1`
  lower bound is required so the plugin is not disabled against a beta core.
- `CHANGELOG.md`: new `6.0.0` entry.

No code changes were needed. The full Matomo 6 breaking-changes catalogue was swept against this
repository — removed PHP APIs, removed HTTP API methods, removed global functions, changed interfaces,
the Monolog 3 / PHP-DI 7 / Symfony 6.4 / php-tracker 4 dependency upgrades, the `#[JsonResponse]`
controller contract, removed Less variables and stylesheets, removed JS/Vue APIs, and the Jest → Vitest
migration — with no hits. `config/config.php` uses `Piwik\DI::decorate()`, which still exists in Matomo 6
and keeps the same `($previous, $container)` decorator signature under PHP-DI 7.

The plugin declares no `composer.json`, `Updates/`, `vue/src`, `phpstan.neon`, `phpcs.xml` or test
workflows, so the corresponding preparation steps do not apply.

The commit is marked `[ignore_release]`: this only establishes Matomo 6 compatibility and nothing can be
released for Matomo 6 until core ships.

## Issue No

Related to the Matomo 6 plugin preparation effort.

## Steps to Replicate the Issue

1. Mount the plugin into a Matomo 6 checkout (PHP 8.1, MySQL 8.0, Node 24) and activate it —
   `./console plugin:activate EnvironmentVariables` succeeds.
2. `./console core:update` reports no pending migrations.
3. `MATOMO_GENERAL_ACTION_URL_CATEGORY_DELIMITER=ZZZ ./console config:get --section=General --key=action_url_category_delimiter`
   returns `"ZZZ"`, confirming the config decorator still overrides settings from the environment on
   Matomo 6.

## Checklist
- [✔] Tested locally or on demo2/demo3?
- [NA] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [✔] Version bumped?
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
- [NA] Documentation updated?
